### PR TITLE
refactor: separate audio highlight state from user highlight state

### DIFF
--- a/lib/src/ui/mushaf/mushaf_page_view.dart
+++ b/lib/src/ui/mushaf/mushaf_page_view.dart
@@ -63,7 +63,7 @@ class MushafPageViewState extends State<MushafPageView> {
   late PageController _pageController;
   int _currentPage = 1;
   int? _selectedVerseKey; // chapterNumber * 1000 + verseNumber
-  int? _audioVerseKey;
+  int? _currentAudioVerseKey;
   bool _showControls = true;
   StreamSubscription? _audioSubscription;
 
@@ -86,14 +86,14 @@ class MushafPageViewState extends State<MushafPageView> {
           if (!mounted) return;
           if (state.currentChapter != null && state.currentVerse != null) {
             final key = state.currentChapter! * 1000 + state.currentVerse!;
-            if (_audioVerseKey != key) {
+            if (_currentAudioVerseKey != key) {
               setState(() {
-                _audioVerseKey = key;
+                _currentAudioVerseKey = key;
               });
             }
-          } else if (state.isPlaying && _audioVerseKey != null) {
+          } else if (!state.isPlaying && _currentAudioVerseKey != null) {
             setState(() {
-              _audioVerseKey = null;
+              _currentAudioVerseKey = null;
             });
           }
         });
@@ -188,7 +188,7 @@ class MushafPageViewState extends State<MushafPageView> {
                             ? _selectedVerseKey
                             : null,
                         audioVerseKey: pageNumber == _currentPage
-                            ? _audioVerseKey
+                            ? _currentAudioVerseKey
                             : null,
                         audioHighlightsColor: widget.audioHighlightsColor,
                         onVerseTap: (chapter, verse) {

--- a/lib/src/ui/mushaf/quran_line_image.dart
+++ b/lib/src/ui/mushaf/quran_line_image.dart
@@ -88,7 +88,7 @@ class QuranLineImage extends StatelessWidget {
                 ..._buildSelectionHighlights(lineWidth),
 
                 // 🎧 Audio Highlight (animated fill)
-                ..._buildAudioHighlights(assetPath, lineWidth),
+                ..._buildAudioHighlights(assetPath),
 
                 // Verse separators (VerseFasel markers)
                 if (markers.isNotEmpty) _buildMarkers(lineWidth, lineHeight),
@@ -100,35 +100,38 @@ class QuranLineImage extends StatelessWidget {
     );
   }
 
-  List<Widget> _buildAudioHighlights(String assetPath, double lineWidth) {
-    if (audioHighlights.isEmpty) {
-      return [
-        Image.asset(
-          assetPath,
-          package: 'imad_flutter',
-          fit: BoxFit.contain,
-          color: textColor,
-          colorBlendMode: textColor != null ? BlendMode.srcIn : null,
-          errorBuilder: (context, error, stackTrace) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  '⚠️ Missing quran-images/\n'
-                  'Download from: github.com/Itqan-community/mushaf-imad-flutter',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 9,
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.error.withValues(alpha: 0.7),
-                  ),
-                ),
-              ),
-            );
-          },
+  Widget baseImage({
+    required final String assetPath,
+    final Color? color,
+    final BlendMode? colorBlendMode,
+  }) => Image.asset(
+    assetPath,
+    package: 'imad_flutter',
+    fit: BoxFit.contain,
+    color: color ?? textColor,
+    colorBlendMode:
+        colorBlendMode ?? (textColor != null ? BlendMode.srcIn : null),
+    errorBuilder: (context, error, stackTrace) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            '⚠️ Missing quran-images/\n'
+            'Download from: github.com/Itqan-community/mushaf-imad-flutter',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 9,
+              color: Theme.of(context).colorScheme.error.withValues(alpha: 0.7),
+            ),
+          ),
         ),
-      ];
+      );
+    },
+  );
+
+  List<Widget> _buildAudioHighlights(String assetPath) {
+    if (audioHighlights.isEmpty) {
+      return [baseImage(assetPath: assetPath)];
     }
 
     return audioHighlights.map((h) {
@@ -136,87 +139,19 @@ class QuranLineImage extends StatelessWidget {
         children: [
           ClipRect(
             clipper: _VerseClipper(0, h.left),
-            child: Image.asset(
-              assetPath,
-              package: 'imad_flutter',
-              fit: BoxFit.contain,
-              color: textColor,
-              colorBlendMode: textColor != null ? BlendMode.srcIn : null,
-              errorBuilder: (context, error, stackTrace) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      '⚠️ Missing quran-images/\n'
-                      'Download from: github.com/Itqan-community/mushaf-imad-flutter',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 9,
-                        color: Theme.of(
-                          context,
-                        ).colorScheme.error.withValues(alpha: 0.7),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
+            child: baseImage(assetPath: assetPath),
           ),
           ClipRect(
             clipper: _VerseClipper(h.left, h.right),
-            child: Image.asset(
-              assetPath,
-              package: 'imad_flutter',
-              fit: BoxFit.contain,
+            child: baseImage(
+              assetPath: assetPath,
               color: audioHighlightsColor ?? Colors.blue,
               colorBlendMode: BlendMode.srcIn,
-              errorBuilder: (context, error, stackTrace) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      '⚠️ Missing quran-images/\n'
-                      'Download from: github.com/Itqan-community/mushaf-imad-flutter',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 9,
-                        color: Theme.of(
-                          context,
-                        ).colorScheme.error.withValues(alpha: 0.7),
-                      ),
-                    ),
-                  ),
-                );
-              },
             ),
           ),
           ClipRect(
             clipper: _VerseClipper(h.right, 1),
-            child: Image.asset(
-              assetPath,
-              package: 'imad_flutter',
-              fit: BoxFit.contain,
-              color: textColor,
-              colorBlendMode: textColor != null ? BlendMode.srcIn : null,
-              errorBuilder: (context, error, stackTrace) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      '⚠️ Missing quran-images/\n'
-                      'Download from: github.com/Itqan-community/mushaf-imad-flutter',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 9,
-                        color: Theme.of(
-                          context,
-                        ).colorScheme.error.withValues(alpha: 0.7),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
+            child: baseImage(assetPath: assetPath),
           ),
         ],
       );

--- a/lib/src/ui/mushaf/quran_page_widget.dart
+++ b/lib/src/ui/mushaf/quran_page_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../data/quran/quran_data_provider.dart';
@@ -159,9 +160,7 @@ class _QuranPageWidgetState extends State<QuranPageWidget> {
                       child: QuranLineImage(
                         page: widget.pageNumber,
                         line: line,
-                        audioHighlights: audioHighlights
-                            .where((h) => h.line == line)
-                            .toList(),
+                        audioHighlights: audioHighlights,
                         audioHighlightsColor: widget.audioHighlightsColor,
                         selectionHighlights: selectionHighlights,
                         markers: markers,
@@ -169,8 +168,10 @@ class _QuranPageWidgetState extends State<QuranPageWidget> {
 
                         textColor: theme.textColor,
                         onTapUpExact: (tapRatio) {
-                          if (widget.onVerseTap == null || versesOnLine.isEmpty)
+                          if (widget.onVerseTap == null ||
+                              versesOnLine.isEmpty) {
                             return;
+                          }
 
                           PageVerseData? target;
 
@@ -189,16 +190,16 @@ class _QuranPageWidgetState extends State<QuranPageWidget> {
                           }
 
                           // 2. Fallback if tapped on empty space or gap between verses
-                          if (target == null) {
-                            target = markers.isNotEmpty
-                                ? markers.last
-                                : versesOnLine.last;
-                          }
+                          target ??= markers.isNotEmpty
+                              ? markers.last
+                              : versesOnLine.last;
 
-                          print(
-                            "Calling onVerseTap with chapter: ${target?.chapter}, verse: ${target?.number}",
-                          );
-                          widget.onVerseTap!(target!.chapter, target.number);
+                          if (kDebugMode) {
+                            print(
+                              "Calling onVerseTap with chapter: ${target.chapter}, verse: ${target.number}",
+                            );
+                          }
+                          widget.onVerseTap!(target.chapter, target.number);
                         },
                       ),
                     );


### PR DESCRIPTION
### Resolves #4 
## Summary
This PR refactors the highlight system by separating the audio playback highlight state from the user selection highlight state.

## Changes
- Introduced a dedicated state for audio highlight.
- Isolated user selection highlight into its own state layer.
- Removed shared highlight coupling logic.
- Enabled customizable audio highlight color without affecting user selection highlight.

## Motivation
Previously, both highlight behaviors were managed within the same state context, which increased coupling and risked visual overlap or unintended overrides.

This refactor improves:
- Separation of concerns
- State clarity and maintainability
- Future extensibility (e.g., adding search highlight support)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable audio highlight color to customize playback highlights.
  * Improved audio-based verse tracking so the currently playing verse is highlighted in sync with playback.

* **Refactor**
  * Split highlight handling into separate audio and selection highlights for clearer visuals.
  * Reworked page/line rendering to scope audio highlights to the visible page and lines, improving highlight accuracy during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->