### PR TITLE
fix: add package parameter to QuranNumbers font in VerseFasel

### DIFF
--- a/lib/src/ui/mushaf/verse_fasel.dart
+++ b/lib/src/ui/mushaf/verse_fasel.dart
@@ -37,9 +37,9 @@ class VerseFasel extends StatelessWidget {
               style: TextStyle(
                 fontSize: size * 0.45,
                 fontWeight: FontWeight.bold,
-                color: Colors.black, // Android uses pure Color.Black
-                fontFamily:
-                    'QuranNumbers', // Using the custom QuranNumbers font requested
+                color: Colors.black,
+                fontFamily: 'QuranNumbers',
+                package: 'imad_flutter',
                 height: 1.0,
               ),
             ),


### PR DESCRIPTION
## Summary
- Fixed the rendering of ayah number text inside verse end markers
- Added `package: 'imad_flutter'` to the `TextStyle` in `VerseFasel` widget
- Without this parameter, Flutter cannot locate the bundled `QuranNumbers.ttf` font when the library is consumed as a package dependency, resulting in standard digits instead of stylized Arabic numbers

## Root Cause
The `SvgPicture.asset` already correctly specified `package: 'imad_flutter'` for the fasel SVG, but the `Text` widget's `TextStyle` was missing the same parameter for the `QuranNumbers` font family. This is a known Flutter requirement — packaged fonts must specify their package name.

## Test Plan
- [x] Verified the fix follows the same pattern used by the SVG asset
- [ ] Visual verification: the ayah numbers inside verse markers should display with the stylized QuranNumbers font instead of default system digits

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced verse number styling configuration to improve code maintainability and ensure consistent font rendering across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->