### PR TITLE
feat: add dark mode support for ReadingHistoryPage

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -581,25 +581,42 @@ class ReadingHistoryPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Reading History')),
-      body: const Center(
+      appBar: AppBar(
+        title: const Text('Reading History'),
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+      ),
+      body: Center(
         child: Padding(
-          padding: EdgeInsets.all(32),
+          padding: const EdgeInsets.all(32),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(Icons.history, size: 64, color: Colors.grey),
-              SizedBox(height: 16),
+              Icon(
+                Icons.history,
+                size: 64,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 16),
               Text(
                 'Reading History Repository',
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
               ),
-              SizedBox(height: 8),
+              const SizedBox(height: 8),
               Text(
                 'Reading history will be available after Hive DAO integration.\n'
                 'Features: Track reading progress, streaks, last-read position.',
                 textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),

--- a/example/test/reading_history_dark_mode_test.dart
+++ b/example/test/reading_history_dark_mode_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:imad_flutter_example/main.dart';
+
+void main() {
+  Widget buildTestApp({required Brightness brightness}) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorSchemeSeed: const Color(0xFF6750A4),
+        useMaterial3: true,
+        brightness: brightness,
+      ),
+      home: const ReadingHistoryPage(),
+    );
+  }
+
+  group('ReadingHistoryPage dark mode support', () {
+    testWidgets('uses theme-aware colors in light mode', (tester) async {
+      await tester.pumpWidget(buildTestApp(brightness: Brightness.light));
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(ReadingHistoryPage));
+      final colorScheme = Theme.of(context).colorScheme;
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.history));
+      expect(icon.color, equals(colorScheme.onSurfaceVariant));
+
+      final titleFinder = find.text('Reading History Repository');
+      expect(titleFinder, findsOneWidget);
+      final titleWidget = tester.widget<Text>(titleFinder);
+      expect(titleWidget.style?.color, equals(colorScheme.onSurface));
+
+      final bodyFinder = find.textContaining('Reading history will be available');
+      expect(bodyFinder, findsOneWidget);
+      final bodyWidget = tester.widget<Text>(bodyFinder);
+      expect(bodyWidget.style?.color, equals(colorScheme.onSurfaceVariant));
+    });
+
+    testWidgets('uses theme-aware colors in dark mode', (tester) async {
+      await tester.pumpWidget(buildTestApp(brightness: Brightness.dark));
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(ReadingHistoryPage));
+      final colorScheme = Theme.of(context).colorScheme;
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.history));
+      expect(icon.color, equals(colorScheme.onSurfaceVariant));
+
+      final titleWidget =
+          tester.widget<Text>(find.text('Reading History Repository'));
+      expect(titleWidget.style?.color, equals(colorScheme.onSurface));
+
+      final bodyWidget = tester
+          .widget<Text>(find.textContaining('Reading history will be available'));
+      expect(bodyWidget.style?.color, equals(colorScheme.onSurfaceVariant));
+    });
+
+    testWidgets('light and dark mode produce different color values',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(brightness: Brightness.light));
+      await tester.pumpAndSettle();
+      final lightContext = tester.element(find.byType(ReadingHistoryPage));
+      final lightColors = Theme.of(lightContext).colorScheme;
+      final lightOnSurface = lightColors.onSurface;
+
+      await tester.pumpWidget(buildTestApp(brightness: Brightness.dark));
+      await tester.pumpAndSettle();
+      final darkContext = tester.element(find.byType(ReadingHistoryPage));
+      final darkColors = Theme.of(darkContext).colorScheme;
+      final darkOnSurface = darkColors.onSurface;
+
+      expect(lightOnSurface, isNot(equals(darkOnSurface)));
+    });
+
+    testWidgets('does not use hardcoded Colors.grey', (tester) async {
+      await tester.pumpWidget(buildTestApp(brightness: Brightness.dark));
+      await tester.pumpAndSettle();
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.history));
+      expect(icon.color, isNot(equals(Colors.grey)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `Colors.grey` and unstyled `TextStyle` in `ReadingHistoryPage` with `Theme.of(context)` color scheme values (`colorScheme.onSurfaceVariant`, `colorScheme.onSurface`)
- AppBar now uses `colorScheme.surface` / `colorScheme.onSurface` for proper theme adaptation
- Text styles use `theme.textTheme.titleLarge` and `theme.textTheme.bodyMedium` for consistency with Material 3 theming
- Add widget tests verifying theme-aware colors render correctly in both light and dark modes

Fixes #68

## Test plan
- [x] Widget test: verifies icon, title, and body text use `colorScheme` colors in light mode
- [x] Widget test: verifies icon, title, and body text use `colorScheme` colors in dark mode
- [x] Widget test: confirms light and dark mode produce different `onSurface` color values
- [x] Widget test: confirms `Colors.grey` is no longer used on the history icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated ReadingHistoryPage colors to use Material 3 theme colors for better light and dark mode support.

* **Tests**
  * Added theming tests to verify correct color application across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->