### PR TITLE
feat: add haptic feedback on verse long press selection

### DIFF
--- a/lib/src/ui/mushaf/mushaf_page_view.dart
+++ b/lib/src/ui/mushaf/mushaf_page_view.dart
@@ -248,6 +248,12 @@ class MushafPageViewState extends State<MushafPageView> {
                                 : key;
                           });
                         },
+                        onVerseLongPress: (chapter, verse) {
+                          final key = chapter * 1000 + verse;
+                          setState(() {
+                            _selectedVerseKey = key;
+                          });
+                        },
                       );
                     },
                   ),

--- a/lib/src/ui/mushaf/quran_line_image.dart
+++ b/lib/src/ui/mushaf/quran_line_image.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../data/quran/quran_data_provider.dart';
 import '../../data/quran/verse_data_provider.dart';
@@ -30,6 +31,7 @@ class QuranLineImage extends StatelessWidget {
   /// contrasts against dark backgrounds (uses BlendMode.srcIn).
   final Color? textColor;
   final void Function(double tapRatio)? onTapUpExact;
+  final void Function(double tapRatio)? onLongPressUpExact;
 
   /// Verse markers that end on this line (for rendering VerseFasel).
   final List<PageVerseData> markers;
@@ -46,6 +48,7 @@ class QuranLineImage extends StatelessWidget {
     this.selectionHighlights = const [],
     this.onTap,
     this.onTapUpExact,
+    this.onLongPressUpExact,
     this.markers = const [],
     this.highlightColor,
     this.textColor,
@@ -74,6 +77,16 @@ class QuranLineImage extends StatelessWidget {
         // Need to define onTap so this GestureDetector wins the gesture arena
         // against the parent MushafPageView's onTap (which toggles controls).
       },
+      onLongPressStart: onLongPressUpExact != null
+          ? (details) {
+              HapticFeedback.mediumImpact();
+              final box = context.findRenderObject() as RenderBox;
+              final localPosition =
+                  box.globalToLocal(details.globalPosition);
+              final tapRatio = localPosition.dx / box.size.width;
+              onLongPressUpExact!(tapRatio);
+            }
+          : null,
       child: AspectRatio(
         aspectRatio: _aspectRatio,
         child: LayoutBuilder(

--- a/lib/src/ui/mushaf/quran_page_widget.dart
+++ b/lib/src/ui/mushaf/quran_page_widget.dart
@@ -23,6 +23,9 @@ class QuranPageWidget extends StatefulWidget {
   /// Called when a verse is tapped. Provides (chapterNumber, verseNumber).
   final void Function(int chapterNumber, int verseNumber)? onVerseTap;
 
+  /// Called when a verse is long-pressed. Provides (chapterNumber, verseNumber).
+  final void Function(int chapterNumber, int verseNumber)? onVerseLongPress;
+
   /// Reading theme data for colors. Defaults to light theme.
   final ReadingThemeData? themeData;
 
@@ -33,6 +36,7 @@ class QuranPageWidget extends StatefulWidget {
     this.audioVerseKey,
     this.audioHighlightsColor,
     this.onVerseTap,
+    this.onVerseLongPress,
     this.themeData,
   });
 
@@ -201,6 +205,36 @@ class _QuranPageWidgetState extends State<QuranPageWidget> {
                           }
                           widget.onVerseTap!(target.chapter, target.number);
                         },
+                        onLongPressUpExact: widget.onVerseLongPress != null
+                            ? (tapRatio) {
+                                if (versesOnLine.isEmpty) return;
+
+                                PageVerseData? target;
+
+                                for (final verse in versesOnLine) {
+                                  final hList = verse.highlights1441.where(
+                                    (h) => h.line == line,
+                                  );
+                                  for (final h in hList) {
+                                    if (tapRatio >= h.left &&
+                                        tapRatio <= h.right) {
+                                      target = verse;
+                                      break;
+                                    }
+                                  }
+                                  if (target != null) break;
+                                }
+
+                                target ??= markers.isNotEmpty
+                                    ? markers.last
+                                    : versesOnLine.last;
+
+                                widget.onVerseLongPress!(
+                                  target.chapter,
+                                  target.number,
+                                );
+                              }
+                            : null,
                       ),
                     );
                   }),


### PR DESCRIPTION
## Summary

- Add `onLongPressStart` gesture handler to `QuranLineImage` that triggers `HapticFeedback.mediumImpact()` when a verse is long-pressed
- Wire `onVerseLongPress` callback through `QuranPageWidget` to `MushafPageView` for verse selection on long press
- Reuse existing verse hit-testing logic for accurate long-press target resolution

Fixes #69

## Test plan

- [ ] Long press a verse on any Quran page and verify haptic feedback is triggered
- [ ] Verify the long-pressed verse gets selected (highlighted)
- [ ] Verify regular tap behavior still works as before (toggle selection)
- [ ] Test on both iOS and Android devices to confirm haptic feedback works on each platform