### PR TITLE
add filter object

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -165,6 +165,13 @@ class LibraryHomePage extends StatelessWidget {
             subtitle: 'Switch between Hafs layouts',
             onTap: () => _push(context, const MushafTypePage()),
           ),
+          // ─── Quran Data provider chapter_filtering_mekkan_medinan───
+          _MenuCard(
+            icon: Icons.filter_list,
+            title: 'Chapter Filtering',
+            subtitle: 'Filter surahs by revelation type: Meccan / Medinan',
+            onTap: () => _push(context, const Chapterfilteringmekkanmedinan()),
+          ),
           _MenuCard(
             icon: Icons.code,
             title: 'Domain Models',
@@ -193,6 +200,107 @@ class LibraryHomePage extends StatelessWidget {
     Navigator.of(context).push(MaterialPageRoute(builder: (_) => page));
   }
 }
+
+class Chapterfilteringmekkanmedinan extends StatefulWidget {
+  const Chapterfilteringmekkanmedinan({super.key});
+
+  @override
+  State<Chapterfilteringmekkanmedinan> createState() =>
+      _ChapterfilteringmekkanmedinanState();
+}
+
+class _ChapterfilteringmekkanmedinanState
+    extends State<Chapterfilteringmekkanmedinan>
+    with TickerProviderStateMixin {
+  late TabController _tabController;
+  late List<ChapterData> chapters;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    chapters = QuranDataProvider.instance.getFilteredChapters(
+      ChapterFilter(revelationType: RevelationType.all),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('chapter filtering mekkan medinan'),
+        bottom: TabBar(
+          controller: _tabController,
+          onTap: (value) {
+            switch (value) {
+              case 0:
+                chapters = QuranDataProvider.instance.getFilteredChapters(
+                  ChapterFilter(revelationType: RevelationType.all),
+                );
+                break;
+              case 1:
+                chapters = QuranDataProvider.instance.getFilteredChapters(
+                  ChapterFilter(revelationType: RevelationType.meccan),
+                );
+                break;
+              case 2:
+                chapters = QuranDataProvider.instance.getFilteredChapters(
+                  ChapterFilter(revelationType: RevelationType.medinan),
+                );
+                break;
+            }
+            setState(() {});
+          },
+          tabs: [
+            Tab(text: "All"),
+            Tab(text: "meccan"),
+            Tab(text: "medinan"),
+          ],
+        ),
+      ),
+      body: ListView.builder(
+        itemCount: chapters.length,
+        itemBuilder: (context, index) {
+          final chapter = chapters[index];
+          return ListTile(
+            leading: CircleAvatar(
+              backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+              child: Text(
+                '${chapter.number}',
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+            title: Text(chapter.englishTitle),
+            trailing: Column(
+              children: [
+                Text(
+                  "${chapter.versesCount} ayat",
+                  style: const TextStyle(fontSize: 12),
+                ),
+                Text(
+                  chapter.isMeccan ? "Meccan" : "Madinan",
+                  style: const TextStyle(fontSize: 12),
+                ),
+                Text(
+                  "page ${chapter.startPage}",
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ],
+            ),
+            subtitle: Text(chapter.arabicTitle),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+}
+
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Section Header

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -228,7 +228,7 @@ class _ChapterfilteringmekkanmedinanState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('chapter filtering mekkan medinan'),
+        title: const Text('Chapter Filtering'),
         bottom: TabBar(
           controller: _tabController,
           onTap: (value) {
@@ -252,9 +252,9 @@ class _ChapterfilteringmekkanmedinanState
             setState(() {});
           },
           tabs: [
-            Tab(text: "All"),
-            Tab(text: "meccan"),
-            Tab(text: "medinan"),
+            Tab(text: 'All'),
+            Tab(text: 'Meccan'),
+            Tab(text: 'Medinan'),
           ],
         ),
       ),
@@ -300,7 +300,6 @@ class _ChapterfilteringmekkanmedinanState
     super.dispose();
   }
 }
-
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Section Header

--- a/lib/imad_flutter.dart
+++ b/lib/imad_flutter.dart
@@ -33,6 +33,7 @@ export 'src/domain/models/audio_source.dart';
 export 'src/domain/models/bookmark.dart';
 export 'src/domain/models/cache_stats.dart';
 export 'src/domain/models/chapter.dart';
+export 'src/domain/models/chapter_filter.dart';
 export 'src/domain/models/chapter_group.dart';
 export 'src/domain/models/last_read_position.dart';
 export 'src/domain/models/mushaf_type.dart';

--- a/lib/src/data/quran/quran_data_provider.dart
+++ b/lib/src/data/quran/quran_data_provider.dart
@@ -1,3 +1,4 @@
+import '../../domain/models/chapter_filter.dart';
 import 'quran_metadata.dart';
 
 /// Provides Quran page data — chapters, juz, and page metadata.
@@ -47,6 +48,25 @@ class QuranDataProvider {
     // Deduplicate
     final seen = <int>{};
     return chapters.where((c) => seen.add(c.number)).toList();
+  }
+
+  /// Get chapters filtered by the given [filter] criteria.
+  ///
+  /// Returns all 114 chapters when no filter is applied.
+  /// Example:
+  /// ```dart
+  /// final meccanChapters = QuranDataProvider.instance.getFilteredChapters(
+  ///   const ChapterFilter(revelationType: RevelationType.meccan),
+  /// );
+  /// ```
+  List<ChapterData> getFilteredChapters(ChapterFilter filter) {
+    return switch (filter.revelationType) {
+      RevelationType.all => [...getAllChapters()],
+      RevelationType.meccan =>
+        getAllChapters().where((c) => c.isMeccan).toList(growable: false),
+      RevelationType.medinan =>
+        getAllChapters().where((c) => !c.isMeccan).toList(growable: false),
+    };
   }
 
   /// Get juz number for a given page.

--- a/lib/src/domain/models/chapter_filter.dart
+++ b/lib/src/domain/models/chapter_filter.dart
@@ -1,0 +1,22 @@
+/// Enum representing the revelation type of a Quran chapter.
+enum RevelationType {
+  /// Show all chapters (no filter).
+  all,
+
+  /// Chapters revealed in Makkah.
+  meccan,
+
+  /// Chapters revealed in Madinah.
+  medinan,
+}
+
+/// Filter object for querying chapters.
+///
+/// Designed to be extensible — future contributors can add
+/// more filter criteria (e.g., verses count range, juz number)
+/// without breaking the existing API.
+class ChapterFilter {
+  /// Filter by revelation type (Meccan, Medinan, or all).
+  final RevelationType revelationType;
+  const ChapterFilter({this.revelationType = RevelationType.all});
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chapter filtering support by revelation type (All, Meccan, Madinan), enabling retrieval of matching chapter lists.
  * Updated the example app with a new tabbed “Chapter Filtering” page to browse chapters by revelation type, showing chapter number, titles, verse count, and start page (with Meccan/Madinan labeling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->